### PR TITLE
Backport PR #18105 on branch v7.1.x (Fix handling of bounded variable-length char arrays in BINARY2 format)

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -323,14 +323,24 @@ class Char(Converter):
             self.binoutput = self._binoutput_var
             self.arraysize = "*"
         else:
-            field.arraysize = field.arraysize.removesuffix("*")
+            # Check if this is a bounded variable-length field
+            is_variable = field.arraysize.endswith("*")
+            numeric_part = field.arraysize.removesuffix("*")
             try:
-                self.arraysize = int(field.arraysize)
+                self.arraysize = int(numeric_part)
             except ValueError:
-                vo_raise(E01, (field.arraysize, "char", field.ID), config)
+                vo_raise(E01, (numeric_part, "char", field.ID), config)
+
             self.format = f"U{self.arraysize:d}"
-            self.binparse = self._binparse_fixed
-            self.binoutput = self._binoutput_fixed
+
+            # For bounded variable-length fields use the variable methods
+            if is_variable:
+                self.binparse = self._binparse_var
+                self.binoutput = self._binoutput_var
+            else:
+                self.binparse = self._binparse_fixed
+                self.binoutput = self._binoutput_fixed
+
             self._struct_format = f">{self.arraysize:d}s"
 
     def supports_empty_values(self, config):
@@ -371,6 +381,10 @@ class Char(Converter):
 
     def _binparse_var(self, read):
         length = self._parse_length(read)
+
+        if self.arraysize != "*" and length > self.arraysize:
+            vo_warn(W46, ("char", self.arraysize), None, None)
+
         return read(length).decode("ascii"), False
 
     def _binparse_fixed(self, read):
@@ -389,6 +403,10 @@ class Char(Converter):
                 value = value.encode("ascii")
             except ValueError:
                 vo_raise(E24, (value, self.field_name))
+
+        if self.arraysize != "*" and len(value) > self.arraysize:
+            vo_warn(W46, ("char", self.arraysize), None, None)
+
         return self._write_length(len(value)) + value
 
     def _binoutput_fixed(self, value, mask):
@@ -424,14 +442,23 @@ class UnicodeChar(Converter):
             self.binoutput = self._binoutput_var
             self.arraysize = "*"
         else:
-            field.arraysize = field.arraysize.removesuffix("*")
+            # Check if this is a bounded variable-length field
+            is_variable = field.arraysize.endswith("*")
+            numeric_part = field.arraysize.removesuffix("*")
             try:
-                self.arraysize = int(field.arraysize)
+                self.arraysize = int(numeric_part)
             except ValueError:
-                vo_raise(E01, (field.arraysize, "unicode", field.ID), config)
+                vo_raise(E01, (numeric_part, "unicode", field.ID), config)
+
             self.format = f"U{self.arraysize:d}"
-            self.binparse = self._binparse_fixed
-            self.binoutput = self._binoutput_fixed
+
+            if is_variable:
+                self.binparse = self._binparse_var
+                self.binoutput = self._binoutput_var
+            else:
+                self.binparse = self._binparse_fixed
+                self.binoutput = self._binoutput_fixed
+
             self._struct_format = f">{self.arraysize * 2:d}s"
 
     def parse(self, value, config=None, pos=None):
@@ -446,6 +473,10 @@ class UnicodeChar(Converter):
 
     def _binparse_var(self, read):
         length = self._parse_length(read)
+
+        if self.arraysize != "*" and length > self.arraysize:
+            vo_warn(W46, ("unicodeChar", self.arraysize), None, None)
+
         return read(length * 2).decode("utf_16_be"), False
 
     def _binparse_fixed(self, read):
@@ -459,8 +490,14 @@ class UnicodeChar(Converter):
     def _binoutput_var(self, value, mask):
         if mask or value is None or value == "":
             return _zero_int
+
+        if self.arraysize != "*" and len(value) > self.arraysize:
+            vo_warn(W46, ("unicodeChar", self.arraysize), None, None)
+            value = value[: self.arraysize]
+
         encoded = value.encode("utf_16_be")
-        return self._write_length(len(encoded) / 2) + encoded
+
+        return self._write_length(len(encoded) // 2) + encoded
 
     def _binoutput_fixed(self, value, mask):
         if mask:
@@ -1441,28 +1478,52 @@ def table_column_to_votable_datatype(column):
         set on a VOTable FIELD element.
     """
     votable_string_dtype = None
+    max_length = None
+    original_arraysize = None
+
     if column.info.meta is not None:
         votable_string_dtype = column.info.meta.get("_votable_string_dtype")
+        # Check if we have stored the original arraysize with bounds
+        # If so, extract the max length
+        original_arraysize = column.info.meta.get("_votable_arraysize")
+        if (
+            original_arraysize is not None
+            and original_arraysize.endswith("*")
+            and not original_arraysize == "*"
+        ):
+            max_length = original_arraysize[:-1]
+
     if column.dtype.char == "O":
+        arraysize = "*"
+
+        # If max length is stored use it to create a bounded var-length array
+        if max_length is not None:
+            arraysize = f"{max_length}*"
+
         if votable_string_dtype is not None:
-            return {"datatype": votable_string_dtype, "arraysize": "*"}
+            return {"datatype": votable_string_dtype, "arraysize": arraysize}
         elif isinstance(column[0], np.ndarray):
             dtype, shape = _all_matching_dtype(column)
             if dtype is not False:
                 result = numpy_to_votable_dtype(dtype, shape)
                 if "arraysize" not in result:
-                    result["arraysize"] = "*"
+                    result["arraysize"] = arraysize
                 else:
                     result["arraysize"] += "*"
                 return result
 
         # All bets are off, do the most generic thing
-        return {"datatype": "unicodeChar", "arraysize": "*"}
+        return {"datatype": "unicodeChar", "arraysize": arraysize}
 
     # For fixed size string columns, datatype here will be unicodeChar,
     # but honor the original FIELD datatype if present.
     result = numpy_to_votable_dtype(column.dtype, column.shape[1:])
     if result["datatype"] == "unicodeChar" and votable_string_dtype == "char":
         result["datatype"] = "char"
+
+    # If we stored the original arraysize, use it instead of what
+    # numpy_to_votable_dtype derives
+    if original_arraysize is not None:
+        result["arraysize"] = original_arraysize
 
     return result

--- a/astropy/io/votable/tests/data/binary2_variable_length_char.xml
+++ b/astropy/io/votable/tests/data/binary2_variable_length_char.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.4">
+  <RESOURCE type="results">
+    <INFO name="QUERY_STATUS" value="OK" />
+    <INFO name="QUERY" value="SELECT TOP 1 access_format FROM ivoa.ObsCore" />
+    <TABLE>
+      <FIELD name="access_format" datatype="char" arraysize="128*" ucd="meta.code.mime" utype="Access.format">
+        <DESCRIPTION>Content format of the dataset</DESCRIPTION>
+      </FIELD>
+      <DATA>
+      <BINARY2>
+        <STREAM encoding='base64'>
+AAAAACphcHBsaWNhdGlvbi94LXZvdGFibGUreG1sO2NvbnRlbnQ9ZGF0YWxpbms=
+        </STREAM>
+      </BINARY2>
+    </DATA>
+</TABLE>
+  </RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
@@ -41,7 +41,7 @@
    <FIELD ID="string_test_2" arraysize="10" datatype="char" name="fixed string test"/>
    <FIELD ID="unicode_test" arraysize="*" datatype="unicodeChar" name="unicode_test"/>
    <FIELD ID="fixed_unicode_test" arraysize="10" datatype="unicodeChar" name="unicode test"/>
-   <FIELD ID="string_array_test" arraysize="4" datatype="char" name="string array test"/>
+   <FIELD ID="string_array_test" arraysize="4*" datatype="char" name="string array test"/>
    <FIELD ID="unsignedByte" datatype="unsignedByte" name="unsignedByte"/>
    <FIELD ID="short" datatype="short" name="short">
     <VALUES null="-32768"/>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -41,7 +41,7 @@
    <FIELD ID="string_test_2" arraysize="10" datatype="char" name="fixed string test"/>
    <FIELD ID="unicode_test" arraysize="*" datatype="unicodeChar" name="unicode_test"/>
    <FIELD ID="fixed_unicode_test" arraysize="10" datatype="unicodeChar" name="unicode test"/>
-   <FIELD ID="string_array_test" arraysize="4" datatype="char" name="string array test"/>
+   <FIELD ID="string_array_test" arraysize="4*" datatype="char" name="string array test"/>
    <FIELD ID="unsignedByte" datatype="unsignedByte" name="unsignedByte"/>
    <FIELD ID="short" datatype="short" name="short">
     <VALUES null="-32768"/>

--- a/astropy/io/votable/tests/data/vizier_b2_votable.xml
+++ b/astropy/io/votable/tests/data/vizier_b2_votable.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE version="1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+  xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
+<!-- VOTable description at http://www.ivoa.net/Documents/latest/VOT.html -->
+<INFO name="service_protocol" value="ASU">  IVOID of the protocol through which the data was retrieved</INFO>
+<INFO name="request_date" value="2025-05-08T00:06:04">  Query execution date</INFO>
+<INFO name="request" value="https://vizier.u-strasbg.fr/viz-bin/votable/-b64?-source=V/127A/mash1&amp;-out.max=20&amp;-out.meta=hu2D">  Full request URL</INFO>
+<INFO name="contact" value="cds-question@unistra.fr">  Email or URL to contact publisher</INFO>
+<INFO name="server_software" value="7.4.6">  Software version</INFO>
+<INFO name="publisher" value="CDS">  Data centre that produced the VOTable</INFO>
+
+<!--
+Execution Reports
+ -->
+
+<RESOURCE ID="yCat_5127" name="V/127A" type="results">
+  <DESCRIPTION>MASH Catalogues of Planetary Nebulae (Parker+ 2006-2008)</DESCRIPTION>  <INFO name="ivoid" value="ivo://cds.vizier/v/127a">    IVOID of underlying data collection  </INFO>
+  <INFO name="creator" value="Parker Q.A.">    First author or institution  </INFO>
+  <INFO name="cites" value="bibcode:2006MNRAS.373...79P">    Article or Data origin sources  </INFO>
+  <INFO name="original_date" value="2006">    Year of the article publication  </INFO>
+  <INFO name="reference_url" value="https://cdsarc.cds.unistra.fr/viz-bin/cat/V/127A">    Dataset landing page  </INFO>
+  <INFO name="publication_date" value="2018-10-17">    Date of first publication in the data centre  </INFO>
+  <INFO name="rights_uri" value="https://cds.unistra.fr/vizier-org/licences_vizier.html">    Licence URI  </INFO>
+
+  <COOSYS ID="J2000" system="eq_FK5" equinox="J2000"/>
+  <TABLE ID="V_127A_mash1" name="V/127A/mash1">
+    <DESCRIPTION>The MASH Catalog of Planetary Nebulae (paper I)</DESCRIPTION>
+    <!-- Definitions of GROUPs and FIELDs -->
+    <FIELD name="n_PNG" ucd="meta.note" datatype="char" arraysize="1"><!-- ucd="NOTE" -->
+      <DESCRIPTION>[TLP] True, Likely or Possible PN nature</DESCRIPTION>
+    </FIELD>
+    <FIELD name="PNG" ucd="meta.id;meta.main" datatype="char" arraysize="12"><!-- ucd="DATA_LINK" -->
+      <DESCRIPTION>Name of PN, based on Galactic position (1)</DESCRIPTION>
+    </FIELD>
+    <FIELD name="Name" ucd="meta.id" datatype="char" arraysize="13"><!-- ucd="?" -->
+      <DESCRIPTION>Usual name of the PN (2)</DESCRIPTION>
+    </FIELD>
+    <FIELD name="RAJ2000" ucd="pos.eq.ra;meta.main" ref="J2000" datatype="double" width="10" precision="4" unit=""><!-- ucd="POS_EQ_RA_MAIN" -->
+      <DESCRIPTION>Right Ascension J2000</DESCRIPTION>
+    </FIELD>
+    <FIELD name="DEJ2000" ucd="pos.eq.dec;meta.main" ref="J2000" datatype="double" width="9" precision="4" unit=""><!-- ucd="POS_EQ_DEC_MAIN" -->
+      <DESCRIPTION>Declination J2000</DESCRIPTION>
+    </FIELD>
+    <FIELD name="MajDiam" ucd="phys.angSize" datatype="float" width="6" precision="1" unit="arcsec"><!-- ucd="?" -->
+      <DESCRIPTION>? Major diameter of the PN from H{alpha} image</DESCRIPTION>
+      <VALUES null="NaN" />
+    </FIELD>
+    <FIELD name="MinDiam" ucd="phys.angSize" datatype="float" width="6" precision="1" unit="arcsec"><!-- ucd="?" -->
+      <DESCRIPTION>? Minor diameter of the PN from H{alpha} image</DESCRIPTION>
+      <VALUES null="NaN" />
+    </FIELD>
+    <FIELD name="CS" ucd="meta.note" datatype="char" arraysize="7*"><!-- ucd="?" -->
+      <DESCRIPTION>Type of central star (4)</DESCRIPTION>
+    </FIELD>
+    <FIELD name="Morph" ucd="src.morph" datatype="char" arraysize="7*"><!-- ucd="?" -->
+      <DESCRIPTION>Morphology of the nebula</DESCRIPTION>
+    </FIELD>
+    <FIELD name="ObsDate" ucd="time.epoch" datatype="int" width="10" unit="'Y:M:D'"><!-- ucd="?" -->
+      <DESCRIPTION>? Date of first spectroscopic observation</DESCRIPTION>
+      <VALUES null="-2147483648" />
+    </FIELD>
+    <FIELD name="img" ucd="meta.note" datatype="char" arraysize="5"><!-- ucd="DATA_LINK" -->
+      <DESCRIPTION>View images and spectra</DESCRIPTION>
+    </FIELD>
+    <FIELD name="AssocData" ucd="meta.bib.page" datatype="char" arraysize="4"><!-- ucd="DATA_LINK" -->
+      <DESCRIPTION>Associated Data web page</DESCRIPTION>
+    </FIELD>
+<DATA><BINARY><STREAM encoding="base64">
+VEcyMDkuMS0wOC4yIFBIUjA2MTUtMDAyNSBAV3Vwo9cKPb/biavN8BIzQsgAAELIAAAAAAAA
+AAAAAVIAJW+BMTAwMSBmaXRzUEcyMjcuMy0xMi4wIFBIUjA2MzMtMTgwOCBAWJaj1wo9cMAy
+I8TV5vgIQYgAAEFwAAAAAAAAAAAAAkVhACVswDEwMDIgZml0c1RHMjEyLjItMDQuNyBQSFIw
+NjMzLTAxMzUgQFiSeuFHrhS/+WL8li/JYkJgAABCSAAAAAAAAAAAAAJFYQAlbjsxMDAzIGZp
+dHNQRzIxNC4yLTAyLjQgUEhSMDY0NS0wMjE3IEBZUO7u7u7uwAJh2VDIP7dCXgAAQjgAAAAA
+AAAAAAACRXMAJWy8MTAwNCBmaXRzTEcyMjMuNi0wNi44IFBIUjA2NDYtMTIzNSBAWWbF+Sxf
+ksApMqGQf25cQiAAAEIUAAAAAAAAAAAAAUUAJXEcMTAwNSBmaXRzTEcyMTkuMS0wMy45IFBI
+UjA2NDgtMDcxOSBAWYuuFHrhR8AdUsX5LF+SQgwAAEIEAAAAAAAAAAAAAkVhACVofjEwMDYg
+Zml0c1RHMjEyLjYtMDAuMCBQSFIwNjUwKzAwMTMgQFmqzMzMzMw/zSfSfSfSfEKIAABB0AAA
+AAAAAAAAAAFCACVuODEwMDcgZml0c1RHMjE1LjUtMDEuNCBQSFIwNjUxLTAyNTcgQFmx64Ue
+uFHAB52VDIP7ckEIAABBCAAAAAAAAAAAAAFSACVm9zEwMDggZml0c1BHMjIxLjgtMDQuMiBQ
+SFIwNjUyLTA5NTEgQFnFLF+SxfjAI7hR64UeuEJwAABCOAAAAAAAAAAAAAJFYQAlbL0xMDA5
+IGZpdHNQRzIyNC4zLTA1LjUgUEhSMDY1Mi0xMjQwIEBZxWnQNp0CwClaKzxNXm9DOwAAQzQA
+AAAAAAAAAAABSQAlbL4xMDEwIGZpdHNURzIyMi44LTA0LjIgUEhSMDY1NC0xMDQ1IEBZ45LF
++SxfwCWFZ4mrze9B2AAAQYAAAAAAAAAAAAABRQAlbLsxMDExIGZpdHNURzIyNC4zLTAzLjQg
+UEhSMDcwMC0xMTQzIEBaQYvyWL8lwCd2L8li/JVCRAAAQjwAAAAAAAAAAAACRWEAJWy8MTAx
+MiBmaXRzTEcyMjEuMC0wMS40IFBIUjA3MDEtMDc0OSBAWlJ64UeuFMAfSj1wo9cJQoYAAEKE
+AAAAAAAAAAAAAkVhACVsuzEwMTMgZml0c1RHMjE3LjIrMDAuOSBQSFIwNzAyLTAzMjQgQFpp
+HrhR64TAC0cccccccUJQAABCMgAAAAAAAAAAAAJFYQAlZvcxMDE0IGZpdHNURzIxNC42KzAy
+LjkgUEhSMDcwNC0wMDExIEBajxfksX5Kv8f///////9BYAAAQWAAAAAAAAAAAAABUgAlbjgx
+MDE1IGZpdHNURzIyNy4yLTAzLjQgUEhSMDcwNS0xNDE5IEBamkRERERDwCyi2C2C2CxBcAAA
+QXAAAAAAAAAAAAABRQAlbLwxMDE2IGZpdHNURzIyMi45LTAxLjEgUEhSMDcwNS0wOTI0IEBa
+nbToG06BwCLOXUw7KhhCqgAAQqAAAAAAAAAAAAABQgAlbLsxMDE3IGZpdHNQRzIzNy45LTA3
+LjIgRlAwNzExLTI1MzEgIEBa+IiIiIiIwDmF+SxfksVEJQAARBYAAAAAAAAAAAACRWEAJW45
+MTAxOCBmaXRzVEcyMjYuNC0wMS4zIFBIUjA3MTEtMTIzOCBAWvuL8li/JcApRLF+SxfkQmIA
+AEJcAAAAAAAAAAAAAlJhACVsvDEwMTkgZml0c0xHMjI1LjIrMDAuMSBQSFIwNzE0LTEwNTEg
+QFsnrhR64UfAJbl1MOyoY0DgAABAoAAAAAAAAAAAAAFFACVvgTEwMjAgZml0 cw==
+</STREAM></BINARY></DATA>
+</TABLE>
+<INFO name="matches" value="20">matching records</INFO>
+
+<INFO name="Warning" value="truncated result (maxtup=20)"/><INFO name="QUERY_STATUS" value="OVERFLOW"> value="truncated result (maxtup=20)"</INFO>
+
+</RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -6,6 +6,7 @@ Test the conversion to/from astropy.table.
 import io
 import os
 import pathlib
+import struct
 import warnings
 
 import numpy as np
@@ -13,8 +14,10 @@ import pytest
 
 from astropy import units as u
 from astropy.io.votable import conf, from_table, is_votable, tree, validate
-from astropy.io.votable.exceptions import E25, W39, W50, VOWarning
+from astropy.io.votable.converters import Char, UnicodeChar, get_converter
+from astropy.io.votable.exceptions import E01, E25, W39, W46, W50, VOWarning
 from astropy.io.votable.table import parse, writeto
+from astropy.io.votable.tree import Field, VOTableFile
 from astropy.table import Column, Table
 from astropy.table.table_helpers import simple_table
 from astropy.utils.compat.optional_deps import HAS_PYARROW
@@ -74,7 +77,7 @@ def test_table(tmp_path):
         ("string_test_2", {"datatype": "char", "arraysize": "10"}),
         ("unicode_test", {"datatype": "unicodeChar", "arraysize": "*"}),
         ("fixed_unicode_test", {"datatype": "unicodeChar", "arraysize": "10"}),
-        ("string_array_test", {"datatype": "char", "arraysize": "4"}),
+        ("string_array_test", {"datatype": "char", "arraysize": "4*"}),
         ("unsignedByte", {"datatype": "unsignedByte"}),
         ("short", {"datatype": "short"}),
         ("int", {"datatype": "int"}),
@@ -516,6 +519,435 @@ def test_validate_output_valid():
     assert isinstance(validate_out, bool)
     # Check that validation output is correct (votable is valid)
     assert validate_out is True
+
+
+def test_binary2_single_bounded_char_array():
+    """
+    Test that variable length char arrays with a max length
+    (arraysize="128*") are read correctly in BINARY2 format.
+    """
+    votable = parse(get_pkg_data_filename("data/binary2_variable_length_char.xml"))
+    table = votable.get_first_table()
+    astropy_table = table.to_table()
+
+    assert len(astropy_table) == 1
+    assert (
+        astropy_table[0]["access_format"]
+        == "application/x-votable+xml;content=datalink"
+    )
+
+    output = io.BytesIO()
+    astropy_table.write(output, format="votable", tabledata_format="binary2")
+    output.seek(0)
+
+    votable2 = parse(output)
+    table2 = votable2.get_first_table()
+    astropy_table2 = table2.to_table()
+
+    assert len(astropy_table2) == 1
+    assert (
+        astropy_table2[0]["access_format"]
+        == "application/x-votable+xml;content=datalink"
+    )
+
+
+def test_binary2_bounded_variable_length_char():
+    """
+    Test that max length variable length char arrays (arraysize="128*")
+    are correctly serialized and deserialized correctly
+    """
+    votable = tree.VOTableFile()
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="bounded_char",
+            datatype="char",
+            arraysize="128*",
+            ID="bounded_char",
+        )
+    )
+
+    table.create_arrays(2)
+    table.array[0]["bounded_char"] = "Short string"
+    table.array[1]["bounded_char"] = "Longer string that still fits the 128 characters"
+
+    for format_name in ["tabledata", "binary", "binary2"]:
+        bio = io.BytesIO()
+
+        if format_name == "binary2":
+            votable.version = "1.3"
+            table._config = table._config or {}
+            table._config["version_1_3_or_later"] = True
+
+        table.format = format_name
+        votable.to_xml(bio)
+        bio.seek(0)
+
+        votable2 = parse(bio)
+        table2 = votable2.get_first_table()
+
+        assert table2.fields[0].arraysize == "128*", (
+            f"Failed to preserve arraysize with format {format_name}"
+        )
+        assert table2.array[0]["bounded_char"] == "Short string", (
+            f"Data mismatch with format {format_name}"
+        )
+        assert (
+            table2.array[1]["bounded_char"]
+            == "Longer string that still fits the 128 characters"
+        ), f"Data mismatch with format {format_name}"
+
+
+def test_binary2_bounded_variable_length_char_edge_cases():
+    """
+    Test edge cases for bounded variable-length char arrays in BINARY2 format
+    """
+    votable = tree.VOTableFile()
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table._config = table._config or {}
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="bounded_char",
+            datatype="char",
+            arraysize="10*",
+            ID="bounded_char",
+        )
+    )
+
+    table.create_arrays(3)
+    table.array[0]["bounded_char"] = ""
+    table.array[1]["bounded_char"] = "1234567890"
+    table.array[2]["bounded_char"] = "12345"
+
+    bio = io.BytesIO()
+
+    votable.version = "1.3"
+    table._config["version_1_3_or_later"] = True
+    table.format = "binary2"
+
+    votable.to_xml(bio)
+    bio.seek(0)
+
+    votable2 = parse(bio)
+    table2 = votable2.get_first_table()
+
+    assert table2.fields[0].arraysize == "10*", "Failed to preserve arraysize"
+    assert table2.array[0]["bounded_char"] == "", "Empty string not preserved"
+    assert table2.array[1]["bounded_char"] == "1234567890", (
+        "Maximum length string not preserved"
+    )
+    assert table2.array[2]["bounded_char"] == "12345", (
+        "Partial length string not preserved"
+    )
+
+
+def test_binary2_char_fields_vizier_data():
+    """
+    Test parsing a VOTable from a Vizier query which includes bounded
+    variable-length char arrays (e.g., arraysize="7*").
+
+    Related astropy issue:
+    https://github.com/astropy/astropy/issues/8737
+    """
+    sample_file = get_pkg_data_filename("data/vizier_b2_votable.xml")
+
+    votable = parse(sample_file)
+    table = votable.get_first_table()
+
+    assert table.fields[7].ID == "CS"
+    assert table.fields[7].arraysize == "7*"
+    assert table.fields[8].ID == "Morph"
+    assert table.fields[8].arraysize == "7*"
+
+    assert table.array[0]["CS"] == ""
+
+    bio = io.BytesIO()
+    table.format = "binary2"
+    votable.version = "1.3"
+    table._config["version_1_3_or_later"] = True
+    votable.to_xml(bio)
+    bio.seek(0)
+
+    votable2 = parse(bio)
+    table2 = votable2.get_first_table()
+
+    assert table2.fields[7].arraysize == "7*"
+    assert table2.fields[8].arraysize == "7*"
+
+    assert table2.array[0]["CS"] == ""
+    assert table2.array[4]["CS"] == ""
+
+
+def test_char_bounds_validation():
+    """
+    Test that char converter correctly validates the bounds.
+    """
+    votable = tree.VOTableFile()
+    field = tree.Field(
+        votable, name="bounded_char", datatype="char", arraysize="2*", ID="bounded_char"
+    )
+
+    converter = get_converter(field)
+
+    long_string = "abcdefgh"
+    with pytest.warns(W46) as record:
+        value, mask = converter.parse(long_string, {}, None)
+
+    assert any("char" in str(w.message) and "2" in str(w.message) for w in record)
+
+    if hasattr(converter, "_binoutput_var"):
+        with pytest.warns(W46) as record:
+            result = converter._binoutput_var(long_string, False)
+
+        assert any("char" in str(w.message) and "2" in str(w.message) for w in record)
+
+
+def test_binary2_bounded_char_warnings():
+    """
+    Test that appropriate warnings are issued when strings exceed
+    the maximum length in bounded variable-length char arrays.
+    """
+    votable = tree.VOTableFile()
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="bounded_char",
+            datatype="char",
+            arraysize="5*",
+            ID="bounded_char",
+        )
+    )
+
+    table.create_arrays(1)
+    table.array[0]["bounded_char"] = "abcdefghijklmnopqrstu"
+
+    bio = io.BytesIO()
+    votable.version = "1.3"
+    table._config = table._config or {}
+    table._config["version_1_3_or_later"] = True
+    table.format = "binary2"
+    votable.to_xml(bio)
+    bio.seek(0)
+
+    votable2 = parse(bio)
+    with pytest.warns(W46) as record:
+        field = votable2.get_first_table().fields[0]
+        value, mask = field.converter.parse("Too long value", {}, None)
+
+    assert any("arraysize" in str(w.message) or "5" in str(w.message) for w in record)
+
+
+def test_binary2_bounded_unichar_valid():
+    """
+    Test that variable length unicodeChars with a maximum length are correctly
+    serialized and deserialized in BINARY2 format.
+    """
+    votable = tree.VOTableFile()
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="bounded_unichar",
+            datatype="unicodeChar",
+            arraysize="10*",
+            ID="bounded_unichar",
+        )
+    )
+
+    table.create_arrays(3)
+    table.array[0]["bounded_unichar"] = ""
+    table.array[1]["bounded_unichar"] = "áéíóú"
+    table.array[2]["bounded_unichar"] = "áéíóúÁÉÍÓ"
+
+    for format_name in ["tabledata", "binary", "binary2"]:
+        bio = io.BytesIO()
+
+        if format_name == "binary2":
+            votable.version = "1.3"
+            table._config = table._config or {}
+            table._config["version_1_3_or_later"] = True
+
+        table.format = format_name
+        votable.to_xml(bio)
+        bio.seek(0)
+
+        votable2 = parse(bio)
+        table2 = votable2.get_first_table()
+
+        assert table2.fields[0].arraysize == "10*", (
+            f"Arraysize not preserved in {format_name} format"
+        )
+
+        assert table2.array[0]["bounded_unichar"] == "", (
+            f"Empty string not preserved in {format_name} format"
+        )
+        assert table2.array[1]["bounded_unichar"] == "áéíóú", (
+            f"Unicode string not preserved in {format_name} format"
+        )
+        assert table2.array[2]["bounded_unichar"] == "áéíóúÁÉÍÓ", (
+            f"Full-length string not preserved in {format_name} format"
+        )
+
+
+def test_unichar_bounds_validation():
+    """
+    Test that unicodeChar converter correctly validates bounds and issues warnings.
+    """
+    votable = tree.VOTableFile()
+    field = tree.Field(
+        votable,
+        name="bounded_unichar",
+        datatype="unicodeChar",
+        arraysize="5*",
+        ID="bounded_unichar",
+    )
+
+    converter = get_converter(field)
+
+    long_string = "áéíóúÁÉÍÓÚabcdefgh"
+    with pytest.warns(W46) as record:
+        value, mask = converter.parse(long_string, {}, None)
+
+    assert any(
+        "unicodeChar" in str(w.message) and "5" in str(w.message) for w in record
+    )
+
+    if hasattr(converter, "_binoutput_var"):
+        with pytest.warns(W46) as record:
+            result = converter._binoutput_var(long_string, False)
+
+        assert any(
+            "unicodeChar" in str(w.message) and "5" in str(w.message) for w in record
+        )
+
+
+def test_char_invalid_arraysize_raises_e01():
+    """
+    Test that an invalid arraysize for a char field raises E01.
+    """
+
+    class DummyField:
+        name = "dummy"
+        ID = "dummy_id"
+        arraysize = "invalid*"
+
+    field = DummyField()
+    config = {}
+
+    with pytest.raises(E01) as excinfo:
+        Char(field, config)
+
+    err_msg = str(excinfo.value)
+    assert "invalid" in err_msg
+    assert "char" in err_msg
+    assert "dummy_id" in err_msg
+
+
+def test_unicodechar_invalid_arraysize_raises_e01():
+    """
+    Test that an invalid arraysize for a unicodechar field raises E01.
+    """
+
+    class DummyField:
+        name = "dummy"
+        ID = "dummy_id"
+        arraysize = "invalid*"
+
+    field = DummyField()
+    config = {}
+
+    with pytest.raises(E01) as excinfo:
+        UnicodeChar(field, config)
+
+    err_msg = str(excinfo.value)
+    assert "invalid" in err_msg
+    assert "unicode" in err_msg
+    assert "dummy_id" in err_msg
+
+
+def test_char_exceeding_arraysize():
+    """
+    Test that appropriate warnings are issued when strings exceed
+    the maximum length.
+    """
+    votable = VOTableFile()
+
+    field = Field(
+        votable, name="field_name", datatype="char", arraysize="5", ID="field_id"
+    )
+    converter = Char(field)
+    test_value = "Value that is too long for the field"
+
+    with pytest.warns(W46) as record:
+        result, mask = converter.parse(test_value)
+
+    assert any("char" in str(w.message) and "5" in str(w.message) for w in record)
+
+    def mock_read(size):
+        if size == 4:
+            return struct.pack(">I", 10)
+        else:
+            return b"0123456789"
+
+    with pytest.warns(W46) as record:
+        result, mask = converter._binparse_var(mock_read)
+
+    assert any("char" in str(w.message) and "5" in str(w.message) for w in record)
+    assert result == "0123456789"
+    assert mask is False
+
+
+def test_unicodechar_binparse_var_exceeds_arraysize():
+    """
+    Test that a warning is issued when reading a unicodeChar array in
+    binary2 serialization that exceeds the specified max length.
+    """
+    votable = tree.VOTableFile()
+    field = tree.Field(
+        votable,
+        name="field_name",
+        datatype="unicodeChar",
+        arraysize="5*",
+        ID="field_id",
+    )
+
+    converter = get_converter(field)
+
+    def mock_read(size):
+        if size == 4:
+            return struct.pack(">I", 10)
+        else:
+            return "0123456789".encode("utf_16_be")
+
+    with pytest.warns(W46) as record:
+        result, mask = converter.binparse(mock_read)
+
+    assert any(
+        "unicodeChar" in str(w.message) and "5" in str(w.message) for w in record
+    )
+
+    assert result == "0123456789"
+    assert mask is False
 
 
 def test_validate_tilde_path(home_is_data):

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1718,8 +1718,12 @@ class Field(
             column.format = self.converter.output_format
         elif isinstance(self.converter, converters.Char):
             column.info.meta["_votable_string_dtype"] = "char"
+            if self.arraysize is not None and self.arraysize.endswith("*"):
+                column.info.meta["_votable_arraysize"] = self.arraysize
         elif isinstance(self.converter, converters.UnicodeChar):
             column.info.meta["_votable_string_dtype"] = "unicodeChar"
+            if self.arraysize is not None and self.arraysize.endswith("*"):
+                column.info.meta["_votable_arraysize"] = self.arraysize
 
     @classmethod
     def from_table_column(cls, votable, column):


### PR DESCRIPTION
Recreated from original PR: https://github.com/astropy/astropy/pull/18170

Backport PR #18105: Fix handling of bounded variable-length char arrays in BINARY2 format